### PR TITLE
Breaking Rest API fixes

### DIFF
--- a/NPPESAPI.net/Core/CustomDateTimeConverter.cs
+++ b/NPPESAPI.net/Core/CustomDateTimeConverter.cs
@@ -12,8 +12,22 @@ namespace Forcura.NPPES.Core
             if (reader.Value == null)
                 return null;
 
-            if (long.TryParse(reader.Value.ToString(), out long longValue))
-                return epoch.AddMilliseconds(longValue * 1000D);
+            var timeToParse = reader.Value.ToString();
+            if (long.TryParse(timeToParse, out long longValue))
+            {
+                // for backward compatibility, it looks like the NPPES folks
+                // found they were sending seconds and not milliseconds
+                // and finally corrected this.  Unfortunately this is breaking
+                // and due to the unplanned nature of their release and inappropriate versioning
+                // its probably best to check validating for seconds and/or milliseconds being
+                // returned here
+                if (timeToParse.Length <= 10)
+                {
+                    return epoch.AddMilliseconds(longValue * 1000D);
+                }
+
+                return epoch.AddMilliseconds(longValue);
+            }
 
             return base.ReadJson(reader, objectType, existingValue, serializer);
         }

--- a/NPPESAPI.net/Core/NPPESResponseConverter.cs
+++ b/NPPESAPI.net/Core/NPPESResponseConverter.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Forcura.NPPES.Core
+{
+    internal class NPPESResponseConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(NPPESResponse);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            // Unfortunately, NPPES API was updated and result_count field was changed
+            // to resultCount without warning.  We'd like to think the name change will stick
+            // however, if the change is reverted along the line we want to be sure we are
+            // compatible both ways.
+            //
+            // We'll continue to review the stability of the NPPES NPI Rest API
+            // and determine future direction of these changes
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
+            object instance = objectType.GetConstructor(Type.EmptyTypes).Invoke(null);
+#else
+            object instance = Activator.CreateInstance(objectType);
+#endif
+
+            // create JObject for future parsing
+            var jObject = JObject.Load(reader);
+
+            // create reader to populate the object
+            using (var jReader = jObject.CreateReader())
+            {
+                jReader.Culture = reader.Culture;
+                jReader.SupportMultipleContent = reader.SupportMultipleContent;
+                jReader.FloatParseHandling = reader.FloatParseHandling;
+                jReader.DateParseHandling = reader.DateParseHandling;
+                jReader.DateFormatString = reader.DateFormatString;
+                jReader.MaxDepth = reader.MaxDepth;
+
+                serializer.Populate(jReader, instance);
+            }
+
+            // now the fun part, check for either resultCount or result_count fields
+#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
+            PropertyInfo[] props = objectType.GetProperties();
+#else
+            PropertyInfo[] props = objectType.GetRuntimeProperties()?.ToArray();
+#endif
+
+            foreach (var jp in jObject.Properties())
+            {
+                if (string.Equals(jp.Name, "resultCount", StringComparison.OrdinalIgnoreCase) || string.Equals(jp.Name, "result_count", StringComparison.OrdinalIgnoreCase))
+                {
+                    PropertyInfo prop = props.FirstOrDefault(pi =>
+                    pi.CanWrite && string.Equals(pi.Name, nameof(NPPESResponse.ResultCount), StringComparison.OrdinalIgnoreCase));
+
+                    if (prop != null)
+                        prop.SetValue(instance, jp.Value.ToObject(prop.PropertyType, serializer));
+                }
+            }
+
+            return instance;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NPPESAPI.net/Core/NPPESTypeConverter.cs
+++ b/NPPESAPI.net/Core/NPPESTypeConverter.cs
@@ -1,7 +1,7 @@
-﻿using Forcura.NPPES.Models;
+﻿using System;
+using Forcura.NPPES.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
 
 namespace Forcura.NPPES.Core
 {

--- a/NPPESAPI.net/Models/NPPESVersion.cs
+++ b/NPPESAPI.net/Models/NPPESVersion.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Forcura.NPPES.Models
 {
@@ -12,10 +10,12 @@ namespace Forcura.NPPES.Models
         /// <summary>
         /// Version 1.0
         /// </summary>
+        [Obsolete("API Versions 1.0 and 2.0 are NOW retired, please switch your application to use API Version 2.1 if you have not already done so. The old links https://npiregistry.cms.hhs.gov/api?version=1.0 , https://npiregistry.cms.hhs.gov/api?version=2.0 , and https://npiregistry.cms.hhs.gov/api (without the version flag) will no longer work. Please contact NPIFiles@cms.hhs.gov if you have further questions.")]
         v1_0,
         /// <summary>
         /// Version 2.0
         /// </summary>
+        [Obsolete("API Versions 1.0 and 2.0 are NOW retired, please switch your application to use API Version 2.1 if you have not already done so. The old links https://npiregistry.cms.hhs.gov/api?version=1.0 , https://npiregistry.cms.hhs.gov/api?version=2.0 , and https://npiregistry.cms.hhs.gov/api (without the version flag) will no longer work. Please contact NPIFiles@cms.hhs.gov if you have further questions.")]
         v2_0,
         /// <summary>
         /// Version 2.1
@@ -27,6 +27,9 @@ namespace Forcura.NPPES.Models
     {
         public static string ToVersionString(this NPPESVersion version)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
+            // we are alerting the consumer to this deprecation
+            // we'll look to remove completely in the next version
             switch (version)
             {
                 case NPPESVersion.v1_0:
@@ -38,6 +41,7 @@ namespace Forcura.NPPES.Models
                 default:
                     return "2.1";
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/NPPESAPI.net/NPPESApiClient.cs
+++ b/NPPESAPI.net/NPPESApiClient.cs
@@ -51,6 +51,7 @@ namespace Forcura.NPPES
                     new AddressPurposeConverter(),
                     new AddressTypeConverter(),
                     new NPPESTypeConverter(),
+                    new NPPESResponseConverter(),
                     new CustomDateTimeConverter()
                 },
                 ContractResolver = new NPPESContractResolver()


### PR DESCRIPTION
These updates address #14 by supporting backward compatibility in the event these changes are suddenly reverted.  I'd like to plan to remove these internal backward compatible changes in the next major version release.

1. Supports `result_count` and `resultCount` properties
2. Supports timestamps as seconds or milliseconds from the epoch
3. Obsolete notice for versions 1.0 and 2.0