### PR TITLE
Closes #8 and #16

### DIFF
--- a/NPPESAPI.net.sln
+++ b/NPPESAPI.net.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2043
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 17.0.31903.59
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPPESAPI.net", "NPPESAPI.net\NPPESAPI.net.csproj", "{70E67FB5-0C1C-4BFA-B813-395555B3A960}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPPESAPITest", "NPPESAPITest\NPPESAPITest.csproj", "{2BEC053C-47A3-4FF3-B37E-0DA356351E28}"

--- a/NPPESAPI.net/Core/NPPESResponseConverter.cs
+++ b/NPPESAPI.net/Core/NPPESResponseConverter.cs
@@ -22,11 +22,7 @@ namespace Forcura.NPPES.Core
             //
             // We'll continue to review the stability of the NPPES NPI Rest API
             // and determine future direction of these changes
-#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             object instance = objectType.GetConstructor(Type.EmptyTypes).Invoke(null);
-#else
-            object instance = Activator.CreateInstance(objectType);
-#endif
 
             // create JObject for future parsing
             var jObject = JObject.Load(reader);
@@ -45,11 +41,7 @@ namespace Forcura.NPPES.Core
             }
 
             // now the fun part, check for either resultCount or result_count fields
-#if NETSTANDARD2_0_OR_GREATER || NET5_0_OR_GREATER
             PropertyInfo[] props = objectType.GetProperties();
-#else
-            PropertyInfo[] props = objectType.GetRuntimeProperties()?.ToArray();
-#endif
 
             foreach (var jp in jObject.Properties())
             {

--- a/NPPESAPI.net/Models/NPPESOtherName.cs
+++ b/NPPESAPI.net/Models/NPPESOtherName.cs
@@ -10,9 +10,9 @@
         /// </summary>
         public string OrganizationName { get; set; }
 
-/// <summary>
-/// The code.
-/// </summary>
+        /// <summary>
+        /// The code.
+        /// </summary>
         public string Code { get; set; }
 
         /// <summary>

--- a/NPPESAPI.net/Models/NPPESVersion.cs
+++ b/NPPESAPI.net/Models/NPPESVersion.cs
@@ -1,22 +1,10 @@
-﻿using System;
-
-namespace Forcura.NPPES.Models
+﻿namespace Forcura.NPPES.Models
 {
     /// <summary>
     /// Versions of the NPPES API
     /// </summary>
     public enum NPPESVersion
     {
-        /// <summary>
-        /// Version 1.0
-        /// </summary>
-        [Obsolete("API Versions 1.0 and 2.0 are NOW retired, please switch your application to use API Version 2.1 if you have not already done so. The old links https://npiregistry.cms.hhs.gov/api?version=1.0 , https://npiregistry.cms.hhs.gov/api?version=2.0 , and https://npiregistry.cms.hhs.gov/api (without the version flag) will no longer work. Please contact NPIFiles@cms.hhs.gov if you have further questions.")]
-        v1_0,
-        /// <summary>
-        /// Version 2.0
-        /// </summary>
-        [Obsolete("API Versions 1.0 and 2.0 are NOW retired, please switch your application to use API Version 2.1 if you have not already done so. The old links https://npiregistry.cms.hhs.gov/api?version=1.0 , https://npiregistry.cms.hhs.gov/api?version=2.0 , and https://npiregistry.cms.hhs.gov/api (without the version flag) will no longer work. Please contact NPIFiles@cms.hhs.gov if you have further questions.")]
-        v2_0,
         /// <summary>
         /// Version 2.1
         /// </summary>
@@ -27,21 +15,13 @@ namespace Forcura.NPPES.Models
     {
         public static string ToVersionString(this NPPESVersion version)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            // we are alerting the consumer to this deprecation
-            // we'll look to remove completely in the next version
             switch (version)
             {
-                case NPPESVersion.v1_0:
-                    return "1.0";
-                case NPPESVersion.v2_0:
-                    return "2.0";
                 case NPPESVersion.v2_1:
                     return "2.1";
                 default:
                     return "2.1";
             }
-#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/NPPESAPI.net/NPPESAPI.net.csproj
+++ b/NPPESAPI.net/NPPESAPI.net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <AssemblyName>Forcura.NPPESAPI</AssemblyName>

--- a/NPPESAPI.net/NPPESAPI.net.csproj
+++ b/NPPESAPI.net/NPPESAPI.net.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
     <AssemblyName>Forcura.NPPESAPI</AssemblyName>
@@ -62,34 +62,28 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.Github" Version="1.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -98,7 +92,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.6">
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/NPPESAPITest/NPPESAPITest.csproj
+++ b/NPPESAPITest/NPPESAPITest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/NPPESAPITest/NPPESAPITest.csproj
+++ b/NPPESAPITest/NPPESAPITest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
@@ -11,43 +11,33 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.6">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NPPESAPITest/NPPESApiClientTests.cs
+++ b/NPPESAPITest/NPPESApiClientTests.cs
@@ -14,8 +14,9 @@ namespace NPPESAPITest
         public async Task NPPESApiClient_ReturnsSingleResultByNPI()
         {
             // arrange
-            // act
             var client = new NPPESApiClient();
+
+            // act
             var result = await client.SearchAsync("1215226147");
 
             // assert

--- a/NPPESAPITest/NPPESRequestBuilderTests.cs
+++ b/NPPESAPITest/NPPESRequestBuilderTests.cs
@@ -42,10 +42,10 @@ namespace NPPESAPITest
         public void NPPESRequestBuilder_VersionProvidedUsesSpecified()
         {
             var request = new NPPESRequestBuilder()
-                .Version(NPPESVersion.v1_0)
+                .Version(NPPESVersion.v2_1)
                 .Build();
 
-            Assert.Equal(NPPESVersion.v1_0, request.Version);
+            Assert.Equal(NPPESVersion.v2_1, request.Version);
         }
     }
 }


### PR DESCRIPTION
- Minor comment update (fixes indenting)
- Removes unsupported frameworks from main project and test project
- Adds .NET7 as a target
- Removes unneeded conditional package references
- Adds and updates conditional package references for .NET6 and .NET7 where necessary
- Package updates where minor patches were available
- Edited .sln to make Visual Studio version 17.0.31903.59 the current and the minimum allowed Visual Studio version. That build number is the first Release version of Visual Studio 2022 (aka Visual Studio 17)