### PR TITLE
Incorrectly named and missing properties in NPPESBasic model and related NPPESContractResolver ("Sex" not "Gender" and "ParentOrganizationLegalBusinessName")

### DIFF
--- a/NPPESAPI.net/Core/NPPESContractResolver.cs
+++ b/NPPESAPI.net/Core/NPPESContractResolver.cs
@@ -80,12 +80,14 @@ namespace Forcura.NPPES.Core
                     { nameof(NPPESBasic.EnumerationDate), "enumeration_date" },
                     { nameof(NPPESBasic.FirstName), "first_name" },
                     { nameof(NPPESBasic.Gender), "gender" },
+                    { nameof(NPPESBasic.Sex), "sex" },
                     { nameof(NPPESBasic.LastName), "last_name" },
                     { nameof(NPPESBasic.LastUpdated), "last_updated" },
                     { nameof(NPPESBasic.MiddleName), "middle_name" },
                     { nameof(NPPESBasic.NamePrefix), "name_prefix" },
                     { nameof(NPPESBasic.NameSuffix), "name_suffix" },
                     { nameof(NPPESBasic.OrganizationName), "organization_name" },
+                    { nameof(NPPESBasic.ParentOrganizationLegalBusinessName), "parent_organization_legal_business_name" },
                     { nameof(NPPESBasic.ReplacementNPI), "replacement_npi" }
                 }
             },

--- a/NPPESAPI.net/Models/NPPESBasic.cs
+++ b/NPPESAPI.net/Models/NPPESBasic.cs
@@ -23,6 +23,11 @@ namespace Forcura.NPPES.Models
         public string OrganizationName { get; set; }
 
         /// <summary>
+        /// Parent Organization Legal Business Name
+        /// </summary>
+        public string ParentOrganizationLegalBusinessName { get; set; }
+
+        /// <summary>
         /// The registered individual's first name.
         /// </summary>
         public string FirstName { get; set; }
@@ -56,7 +61,12 @@ namespace Forcura.NPPES.Models
         /// The registered Individual's gender.
         /// </summary>
         public string Gender { get; set; }
-
+        
+        /// <summary>
+        /// The registered Individual's sex.
+        /// </summary>
+        public string Sex { get; set; }
+        
         /// <summary>
         /// The time the record was created.
         /// </summary>


### PR DESCRIPTION
Adds new properties and setting of them to NPPESBasic class object

- Adds 'Sex" to align with API returns since 'Gender' doesn't exist (may have in the past, but it's not there in https://npiregistry.cms.hhs.gov/api/?version=2.1 (left 'Gender' property as is).  Also adds mapping for this new 'Sex' property.

- Adds new "ParentOrganizationLegalBusinessName" property to NPPESBasic and related mapping from parent_organization_legal_business_name